### PR TITLE
Add support in new option ignore

### DIFF
--- a/test.js
+++ b/test.js
@@ -100,6 +100,19 @@ test('options', function () {
 	}), ['a(\\1)', 'b[c{d}]']);
 });
 
+test('ignore', function() {
+	var withQuotes = 'click.super:on(:not([attr="x()"][attr2=\'y()\']))';
+	var withQuotesRes = ['click.super:on(', [':not(', ['[attr="x()"][attr2=\'y()\']'] ,')'] ,')'];
+	var opts = {
+		brackets: ['()'],
+		ignore: ['"', "'"]
+	};
+	assert.deepEqual(paren(withQuotes, opts), withQuotesRes);
+	assert.equal(stringify(withQuotesRes), withQuotes);
+	assert.equal(stringify(paren(withQuotes)), withQuotes);
+	// assert.deepEqual(paren(stringify(withQuotesRes)), withQuotesRes);
+});
+
 test('flat', function () {
 	var typical = 'click.super:on(:not(:nth-child(5)))'
 	var typicalRes = ['click.super:on(\\3)', '5', ':nth-child(\\1)', ':not(\\2)'];


### PR DESCRIPTION
Add new option "ignore" which should include chars that if brackets are between these chars, parsing should not occur for those brackets.

For example:

In case of `a ( b ( "text(a) " ) z )` while `options = {brackets : ['()'] }` , result should be:
`[ "a (" , [ " b (" , [ " \"text(", [ "a" ], ") \" " ] , ") z " ] , ")" ]`.

But,

in case of `a ( b ( "text(a) " ) z )` while `options = {brackets : ['()'] , ignore : ['"'] }` , result should be:
`[ "a (" ,[ " b (" ,[ " \"text(a) \" " ], ") z " ],")" ]`.

Notice that the brackets including the string "a" were not parsed as they should at the second example, thanks to the new ignore feature.